### PR TITLE
Rewrite the RX interrupt to remove goto and simplify debug statements

### DIFF
--- a/src/include/rfm12_core.h
+++ b/src/include/rfm12_core.h
@@ -47,10 +47,10 @@
 #define SYNC_LSB 0xD4
 
 //these are the states for the receive/transmit state machine
-#define STATE_RX_IDLE 0
-#define STATE_RX_ACTIVE 1
-#define STATE_TX 2
-#define STATE_POWER_DOWN 3
+// Was individual define statements STATE_POWER_DOWN Was = 2
+typedef enum{
+STATE_RX_IDLE, STATE_RX_ACTIVE, STATE_TX, STATE_TX_END, STATE_TX_RESET, STATE_POWER_DOWN
+} radio_state;
 
 
 //packet header length in bytes

--- a/src/include/rfm12_core.h
+++ b/src/include/rfm12_core.h
@@ -18,6 +18,19 @@
  * @author Peter Fuhrmann, Hans-Gert Dahmen, Soeren Heisrath
  */
 
+
+ /** \file rfm12_core.h
+  * \brief rfm12 constants and macros
+  * \author Hans-Gert Dahmen
+  * \author Peter Fuhrmann
+  * \author Soeren Heisrath
+  * \version 0.9.1
+  * \date 2019/09/10
+  *
+  * This header contains rfm12 specific constants
+  * and macros that help operate the radio.
+  */
+
 #ifndef _RFM12_CORE_H
 #define _RFM12_CORE_H
 
@@ -42,235 +55,6 @@
 
 //packet header length in bytes
 #define PACKET_OVERHEAD 3
-
-
-/************************
-* LIBRARY DEFAULT SETTINGS
- */
-
-
-#ifdef PWRMGT_DEFAULT
-	#warning "You are using the PWRMGT_DEFAULT makro directly in your rfm12_config.h - this is no longer supported."
-	#warning "RFM12_USE_WAKEUP_TIMER and RFM12_LOW_BATT_DETECTOR care about this on their own now. just remove PWRMGT_DEFAULT if you needed it for that."
-	#warning "if you need the clock output, use the new RFM12_USE_CLOCK_OUTPUT instead!"
-	#undef PWRMGT_DEFAULT
-#endif
-
-//if notreturns is not defined, we won't use this feature
-#ifndef RFM12_NORETURNS
-	#define RFM12_NORETURNS 0
-#endif
-
-//if transmit only is not defined, we won't use this feature
-#ifndef RFM12_TRANSMIT_ONLY
-	#define RFM12_TRANSMIT_ONLY 0
-#endif
-
-//if transmit only is on, we need to turn of collision detection
-#if RFM12_TRANSMIT_ONLY
-	//disable collision detection, as we won't be able to receive data
-	#ifdef RFM12_NOCOLLISIONDETECTION
-		#undef RFM12_NOCOLLISIONDETECTION
-	#endif
-	#define RFM12_NOCOLLISIONDETECTION 1
-#endif
-
-//if nocollisiondetection is not defined, we won't use this feature
-#ifndef RFM12_NOCOLLISIONDETECTION
-	#define RFM12_NOCOLLISIONDETECTION 0
-#endif
-
-//if livectrl is not defined, we won't use this feature
-#ifndef RFM12_LIVECTRL
-	#define RFM12_LIVECTRL 0
-#endif
-
-//if low battery detector is not defined, we won't use this feature
-#ifndef RFM12_LOW_BATT_DETECTOR
-	#define RFM12_LOW_BATT_DETECTOR 0
-#endif
-
-#ifndef RFM12_USE_CLOCK_OUTPUT
-	#define RFM12_USE_CLOCK_OUTPUT 0
-#endif
-
-#if RFM12_USE_CLOCK_OUTPUT
-	//Enable Xtal oscillator
-	#define PWRMGMT_CLCKOUT (RFM12_PWRMGT_EX)
-#else
-	//Disable Clock output
-	#define PWRMGMT_CLCKOUT (RFM12_PWRMGT_DC)
-#endif
-
-//if the low battery detector feature is used, we will set some extra pwrmgmt options
-#if RFM12_LOW_BATT_DETECTOR
-	//define PWRMGMT_LOW_BATT  with low batt detector
-	//it will be used later
-	#define PWRMGMT_LOW_BATT (RFM12_PWRMGT_EB)
-	
-	//check if the default power management setting has the LB bit set
-	//and warn the user if it's not
-	#ifdef PWRMGT_DEFAULT
-		#if !((PWRMGT_DEFAULT) & RFM12_PWRMGT_EB)
-			#warning "You are using the RFM12 low battery detector, but PWRMGT_DEFAULT has the low battery detector bit unset."
-		#endif
-	#endif
-#else
-	#define PWRMGMT_LOW_BATT 0
-#endif /* RFM12_LOW_BATT_DETECTOR */
-
-//if wakeuptimer is not defined, we won't use this feature
-#ifndef RFM12_USE_WAKEUP_TIMER
-	#define RFM12_USE_WAKEUP_TIMER 0
-#endif
-
-//if wakeuptimer is on, we will set the default power management to use the wakeup timer
-#if RFM12_USE_WAKEUP_TIMER
-	//define PWRMGMT_LOW_BATT  with low batt detector
-	//it will be used later
-	#define PWRMGMT_WKUP (RFM12_PWRMGT_EW)
-	
-	//check if the default power management setting has the EW bit set
-	//and warn the user if it's not
-	#ifdef PWRMGT_DEFAULT
-		#if !((PWRMGT_DEFAULT) & RFM12_PWRMGT_EW)
-			#warning "You are using the RFM12 wakeup timer, but PWRMGT_DEFAULT has the wakeup timer bit unset."
-		#endif
-	#endif
-
-	//enable powermanagement shadowing
-	#define RFM12_PWRMGT_SHADOW 1
-#else
-	#define PWRMGMT_WKUP 0
-#endif /* RFM12_USE_WAKEUP_TIMER */
-
-//if ASK tx is not defined, we won't use this feature
-#ifndef RFM12_TRANSMIT_ASK
-	#define RFM12_TRANSMIT_ASK 0
-#endif
-
-//if receive ASK is not defined, we won't use this feature
-#ifndef RFM12_RECEIVE_ASK
-	#define RFM12_RECEIVE_ASK 0
-#endif
-
-//if software spi is not defined, we won't use this feature
-#ifndef RFM12_SPI_SOFTWARE
-	#define RFM12_SPI_SOFTWARE 0
-#endif
-
-//if uart debug is not defined, we won't use this feature
-#ifndef RFM12_UART_DEBUG
-	#define RFM12_UART_DEBUG 0
-#endif
-
-#ifndef RFM12_PWRMGT_SHADOW
-	#define RFM12_PWRMGT_SHADOW 0
-#endif
-
-//default value for powermanagement register
-#ifndef PWRMGT_DEFAULT
-	#define PWRMGT_DEFAULT (PWRMGMT_CLCKOUT | PWRMGMT_WKUP | PWRMGMT_LOW_BATT)
-#endif
-
-//define a default receive power management mode
-#if RFM12_TRANSMIT_ONLY
-	//the receiver is turned off by default in transmit only mode
-	#define PWRMGT_RECEIVE (RFM12_CMD_PWRMGT | PWRMGT_DEFAULT)
-#else
-	//the receiver is turned on by default in normal mode
-	#define PWRMGT_RECEIVE (RFM12_CMD_PWRMGT | PWRMGT_DEFAULT | RFM12_PWRMGT_ER)
-#endif
-
-//default channel free time, if not defined elsewhere
-#ifndef CHANNEL_FREE_TIME
-	#define CHANNEL_FREE_TIME 200
-#endif
-
-/*
- * backward compatibility for the spi stuff
- * these values weren't set in older revisions of this library
- * so they're now assumed to be on the same pin/port.
- * otherwise these defines serve to configure the software SPI ports
- */
-#ifndef DDR_MOSI
-	#define DDR_MOSI DDR_SPI
-	#define PORT_MOSI PORT_SPI
-#endif
-
-#ifndef DDR_MISO
-	#define DDR_MISO DDR_SPI
-	#define PIN_MISO PIN_SPI
-#endif
-
-#ifndef DDR_SCK
-	#define DDR_SCK DDR_SPI
-	#define PORT_SCK PORT_SPI
-#endif
-
-#ifndef DDR_SPI_SS
-	#define DDR_SPI_SS DDR_SPI
-	#define PORT_SPI_SS PORT_SPI
-#endif
-
-/*
- * backward compatibility for rf channel settings
- * these values weren't set in the config in older revisions of this library
- * so we assume defaults here.
- */
-
-#ifndef RFM12_XTAL_LOAD
-	#define                        RFM12_XTAL_LOAD RFM12_XTAL_11_5PF
-#endif
-
-#ifndef RFM12_POWER
-	#define RFM12_POWER            RFM12_TXCONF_POWER_0
-#endif
-
-#ifndef FSK_SHIFT
-	#define FSK_SHIFT 125000
-#endif
-
-#ifndef RFM12_RSSI_THRESHOLD
-	#define RFM12_RSSI_THRESHOLD   RFM12_RXCTRL_RSSI_79
-#endif
-
-#ifndef RFM12_FILTER_BW
-	#define RFM12_FILTER_BW        RFM12_RXCTRL_BW_400
-#endif
-
-#ifndef RFM12_LNA_GAIN
-	#define RFM12_LNA_GAIN         RFM12_RXCTRL_LNA_6
-#endif
-
-#ifndef RFM12_LBD_VOLTAGE
-	#define RFM12_LBD_VOLTAGE      RFM12_LBD_VOLTAGE_3V7
-#endif
-
-#ifndef RFM12_CLOCK_OUT_FREQUENCY
-	#define RFM12_CLOCK_OUT_FREQUENCY RFM12_CLOCK_OUT_FREQUENCY_1_00_MHz
-#endif
-
-#ifndef RFM12_FREQUENCY
-	#ifndef FREQ
-		#error "RFM12_FREQUENCY not defined."
-	#else
-		#define RFM12_FREQUENCY FREQ
-		#warning "using FREQ for RFM12_FREQUENCY. Please use RFM12_FREQUENCY in the future!"
-	#endif
-#endif
-
-//baseband selection
-#if (RFM12_BASEBAND) == RFM12_BAND_433
-	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_433(x)
-#elif (RFM12_BASEBAND) == RFM12_BAND_868
-	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_868(x)
-#elif (RFM12_BASEBAND) == RFM12_BAND_915
-	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_915(x)
-#else
-	#error "Unsupported RFM12 baseband selected."
-#endif
-
 
 /************************
 * HELPER MACROS

--- a/src/include/rfm12_core.h
+++ b/src/include/rfm12_core.h
@@ -54,7 +54,7 @@ STATE_RX_IDLE, STATE_RX_ACTIVE, STATE_TX, STATE_TX_END, STATE_TX_RESET, STATE_PO
 
 
 //packet header length in bytes
-#define PACKET_OVERHEAD 3
+#define RFM12_TRX_OVERHEAD 3
 
 /************************
 * HELPER MACROS

--- a/src/include/rfm12_defaults.h
+++ b/src/include/rfm12_defaults.h
@@ -1,0 +1,263 @@
+/**** RFM 12 library for Atmel AVR Microcontrollers *******
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA.
+ *
+ * @author Peter Fuhrmann, Hans-Gert Dahmen, Soeren Heisrath
+ */
+
+
+  /** \file rfm12_defaults.h
+   * \brief rfm12 default configuration
+   * \author Hans-Gert Dahmen
+   * \author Peter Fuhrmann
+   * \author Soeren Heisrath
+   * \version 0.9.1
+   * \date 2019/09/10
+   *
+   * This header contains all the default configurations for the rfm12 module.
+   */
+
+ #ifndef _RFM12_DEFAULTS_H
+ #define _RFM12_DEFAULTS_H
+
+ /************************
+ * LIBRARY DEFAULT SETTINGS
+  */
+
+
+ #ifdef PWRMGT_DEFAULT
+ 	#warning "You are using the PWRMGT_DEFAULT makro directly in your rfm12_config.h - this is no longer supported."
+ 	#warning "RFM12_USE_WAKEUP_TIMER and RFM12_LOW_BATT_DETECTOR care about this on their own now. just remove PWRMGT_DEFAULT if you needed it for that."
+ 	#warning "if you need the clock output, use the new RFM12_USE_CLOCK_OUTPUT instead!"
+ 	#undef PWRMGT_DEFAULT
+ #endif
+
+ //if notreturns is not defined, we won't use this feature
+ #ifndef RFM12_NORETURNS
+ 	#define RFM12_NORETURNS 0
+ #endif
+
+ //if transmit only is not defined, we won't use this feature
+ #ifndef RFM12_TRANSMIT_ONLY
+ 	#define RFM12_TRANSMIT_ONLY 0
+ #endif
+
+ //if transmit only is on, we need to turn of collision detection
+ #if RFM12_TRANSMIT_ONLY
+ 	//disable collision detection, as we won't be able to receive data
+ 	#ifdef RFM12_NOCOLLISIONDETECTION
+ 		#undef RFM12_NOCOLLISIONDETECTION
+ 	#endif
+ 	#define RFM12_NOCOLLISIONDETECTION 1
+ #endif
+
+ //if nocollisiondetection is not defined, we won't use this feature
+ #ifndef RFM12_NOCOLLISIONDETECTION
+ 	#define RFM12_NOCOLLISIONDETECTION 0
+ #endif
+
+ //if livectrl is not defined, we won't use this feature
+ #ifndef RFM12_LIVECTRL
+ 	#define RFM12_LIVECTRL 0
+ #endif
+
+ //if low battery detector is not defined, we won't use this feature
+ #ifndef RFM12_LOW_BATT_DETECTOR
+ 	#define RFM12_LOW_BATT_DETECTOR 0
+ #endif
+
+ #ifndef RFM12_USE_CLOCK_OUTPUT
+ 	#define RFM12_USE_CLOCK_OUTPUT 0
+ #endif
+
+ #if RFM12_USE_CLOCK_OUTPUT
+ 	//Enable Xtal oscillator
+ 	#define PWRMGMT_CLCKOUT (RFM12_PWRMGT_EX)
+ #else
+ 	//Disable Clock output
+ 	#define PWRMGMT_CLCKOUT (RFM12_PWRMGT_DC)
+ #endif
+
+ //if the low battery detector feature is used, we will set some extra pwrmgmt options
+ #if RFM12_LOW_BATT_DETECTOR
+ 	//define PWRMGMT_LOW_BATT  with low batt detector
+ 	//it will be used later
+ 	#define PWRMGMT_LOW_BATT (RFM12_PWRMGT_EB)
+
+ 	//check if the default power management setting has the LB bit set
+ 	//and warn the user if it's not
+ 	#ifdef PWRMGT_DEFAULT
+ 		#if !((PWRMGT_DEFAULT) & RFM12_PWRMGT_EB)
+ 			#warning "You are using the RFM12 low battery detector, but PWRMGT_DEFAULT has the low battery detector bit unset."
+ 		#endif
+ 	#endif
+ #else
+ 	#define PWRMGMT_LOW_BATT 0
+ #endif /* RFM12_LOW_BATT_DETECTOR */
+
+ //if wakeuptimer is not defined, we won't use this feature
+ #ifndef RFM12_USE_WAKEUP_TIMER
+ 	#define RFM12_USE_WAKEUP_TIMER 0
+ #endif
+
+ //if wakeuptimer is on, we will set the default power management to use the wakeup timer
+ #if RFM12_USE_WAKEUP_TIMER
+ 	//define PWRMGMT_LOW_BATT  with low batt detector
+ 	//it will be used later
+ 	#define PWRMGMT_WKUP (RFM12_PWRMGT_EW)
+
+ 	//check if the default power management setting has the EW bit set
+ 	//and warn the user if it's not
+ 	#ifdef PWRMGT_DEFAULT
+ 		#if !((PWRMGT_DEFAULT) & RFM12_PWRMGT_EW)
+ 			#warning "You are using the RFM12 wakeup timer, but PWRMGT_DEFAULT has the wakeup timer bit unset."
+ 		#endif
+ 	#endif
+
+ 	//enable powermanagement shadowing
+ 	#define RFM12_PWRMGT_SHADOW 1
+ #else
+ 	#define PWRMGMT_WKUP 0
+ #endif /* RFM12_USE_WAKEUP_TIMER */
+
+ //if ASK tx is not defined, we won't use this feature
+ #ifndef RFM12_TRANSMIT_ASK
+ 	#define RFM12_TRANSMIT_ASK 0
+ #endif
+
+ //if receive ASK is not defined, we won't use this feature
+ #ifndef RFM12_RECEIVE_ASK
+ 	#define RFM12_RECEIVE_ASK 0
+ #endif
+
+ //if software spi is not defined, we won't use this feature
+ #ifndef RFM12_SPI_SOFTWARE
+ 	#define RFM12_SPI_SOFTWARE 0
+ #endif
+
+ //if uart debug is not defined, we won't use this feature
+ #ifndef RFM12_UART_DEBUG
+ 	#define RFM12_UART_DEBUG 0
+ #endif
+
+ #ifndef RFM12_PWRMGT_SHADOW
+ 	#define RFM12_PWRMGT_SHADOW 0
+ #endif
+
+ //default value for powermanagement register
+ #ifndef PWRMGT_DEFAULT
+ 	#define PWRMGT_DEFAULT (PWRMGMT_CLCKOUT | PWRMGMT_WKUP | PWRMGMT_LOW_BATT)
+ #endif
+
+ //define a default receive power management mode
+ #if RFM12_TRANSMIT_ONLY
+ 	//the receiver is turned off by default in transmit only mode
+ 	#define PWRMGT_RECEIVE (RFM12_CMD_PWRMGT | PWRMGT_DEFAULT)
+ #else
+ 	//the receiver is turned on by default in normal mode
+ 	#define PWRMGT_RECEIVE (RFM12_CMD_PWRMGT | PWRMGT_DEFAULT | RFM12_PWRMGT_ER)
+ #endif
+
+ //default channel free time, if not defined elsewhere
+ #ifndef CHANNEL_FREE_TIME
+ 	#define CHANNEL_FREE_TIME 200
+ #endif
+
+ /*
+  * backward compatibility for the spi stuff
+  * these values weren't set in older revisions of this library
+  * so they're now assumed to be on the same pin/port.
+  * otherwise these defines serve to configure the software SPI ports
+  */
+ #ifndef DDR_MOSI
+ 	#define DDR_MOSI DDR_SPI
+ 	#define PORT_MOSI PORT_SPI
+ #endif
+
+ #ifndef DDR_MISO
+ 	#define DDR_MISO DDR_SPI
+ 	#define PIN_MISO PIN_SPI
+ #endif
+
+ #ifndef DDR_SCK
+ 	#define DDR_SCK DDR_SPI
+ 	#define PORT_SCK PORT_SPI
+ #endif
+
+ #ifndef DDR_SPI_SS
+ 	#define DDR_SPI_SS DDR_SPI
+ 	#define PORT_SPI_SS PORT_SPI
+ #endif
+
+ /*
+  * backward compatibility for rf channel settings
+  * these values weren't set in the config in older revisions of this library
+  * so we assume defaults here.
+  */
+
+ #ifndef RFM12_XTAL_LOAD
+ 	#define                        RFM12_XTAL_LOAD RFM12_XTAL_11_5PF
+ #endif
+
+ #ifndef RFM12_POWER
+ 	#define RFM12_POWER            RFM12_TXCONF_POWER_0
+ #endif
+
+ #ifndef FSK_SHIFT
+ 	#define FSK_SHIFT 125000
+ #endif
+
+ #ifndef RFM12_RSSI_THRESHOLD
+ 	#define RFM12_RSSI_THRESHOLD   RFM12_RXCTRL_RSSI_79
+ #endif
+
+ #ifndef RFM12_FILTER_BW
+ 	#define RFM12_FILTER_BW        RFM12_RXCTRL_BW_400
+ #endif
+
+ #ifndef RFM12_LNA_GAIN
+ 	#define RFM12_LNA_GAIN         RFM12_RXCTRL_LNA_6
+ #endif
+
+ #ifndef RFM12_LBD_VOLTAGE
+ 	#define RFM12_LBD_VOLTAGE      RFM12_LBD_VOLTAGE_3V7
+ #endif
+
+ #ifndef RFM12_CLOCK_OUT_FREQUENCY
+ 	#define RFM12_CLOCK_OUT_FREQUENCY RFM12_CLOCK_OUT_FREQUENCY_1_00_MHz
+ #endif
+
+ #ifndef RFM12_FREQUENCY
+ 	#ifndef FREQ
+ 		#error "RFM12_FREQUENCY not defined."
+ 	#else
+ 		#define RFM12_FREQUENCY FREQ
+ 		#warning "using FREQ for RFM12_FREQUENCY. Please use RFM12_FREQUENCY in the future!"
+ 	#endif
+ #endif
+
+ //baseband selection
+ #if (RFM12_BASEBAND) == RFM12_BAND_433
+ 	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_433(x)
+ #elif (RFM12_BASEBAND) == RFM12_BAND_868
+ 	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_868(x)
+ #elif (RFM12_BASEBAND) == RFM12_BAND_915
+ 	#define RFM12_FREQUENCY_CALC(x) RFM12_FREQUENCY_CALC_915(x)
+ #else
+ 	#error "Unsupported RFM12 baseband selected."
+ #endif
+
+ #endif /* _RFM12_DEFAULTS_H */

--- a/src/include/rfm12_hw.h
+++ b/src/include/rfm12_hw.h
@@ -18,6 +18,18 @@
  * @author Peter Fuhrmann, Hans-Gert Dahmen, Soeren Heisrath
  */
 
+  /** \file rfm12_hw.h
+   * \brief rfm12 registers and configuration definitions
+   * \author Hans-Gert Dahmen
+   * \author Peter Fuhrmann
+   * \author Soeren Heisrath
+   * \version 0.9.1
+   * \date 2019/09/10
+   *
+   * This header contains rfm12 definitions of the register names and values
+   * There are also a few calculations macros
+   */
+
 /* Configuration setting command
 	Bit el enables the internal data register.
 	Bit ef enables the FIFO mode. If ef=0 then DATA (pin 6) and DCLK (pin 7) are used for data and data clock output.

--- a/src/rfm12.c
+++ b/src/rfm12.c
@@ -138,8 +138,10 @@ void rfm12_poll(void)
 ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 #endif
 {
-	uint8_t interrupt_high_inactive = nIRQ_PIN & _BV(BIT_nIRQ); // Masked input of interrupt pin for PCINT
-	if(interrupt_high_inactive)return;
+	#ifdef USE_INT_PIN_CHECK
+		uint8_t interrupt_high_inactive = nIRQ_PIN & _BV(BIT_nIRQ); // Masked input of interrupt pin for PCINT
+		if(interrupt_high_inactive)return;
+	#endif
 	RFM12_INT_OFF();
 	uint8_t status;
 	uint8_t recheck_interrupt  = 1;

--- a/src/rfm12.c
+++ b/src/rfm12.c
@@ -49,6 +49,7 @@
  * the order in which they are included is important
 */
 #include "include/rfm12_hw.h"
+#include "include/rfm12_defaults.h"
 #include "include/rfm12_core.h"
 #include "rfm12.h"
 
@@ -115,11 +116,11 @@ rfm12_control_t ctrl;
 * microcontroller - by pulling the nIRQ pin low - on the following events:
 * - The TX register is ready to receive the next byte (RGIT)
 * - The FIFO has received the preprogrammed amount of bits (FFIT)
-* - Power-on reset (POR) 
-* - FIFO overflow (FFOV) / TX register underrun (RGUR) 
-* - Wake-up timer timeout (WKUP) 
-* - Negative pulse on the interrupt input pin nINT (EXT) 
-* - Supply voltage below the preprogrammed value is detected (LBD) 
+* - Power-on reset (POR)
+* - FIFO overflow (FFOV) / TX register underrun (RGUR)
+* - Wake-up timer timeout (WKUP)
+* - Negative pulse on the interrupt input pin nINT (EXT)
+* - Supply voltage below the preprogrammed value is detected (LBD)
 *
 * The rfm12 status register is read to determine which event has occured.
 * Reading the status register will clear the event flags.

--- a/src/rfm12.c
+++ b/src/rfm12.c
@@ -161,18 +161,14 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 		//the first one.
 		recheck_interrupt = 0;
 
-		#if RFM12_UART_DEBUG >= 2
-			uart_putc('S');
-			uart_putc(status);
-		#endif
+        UART_DEBUG_PUTC('S');
+        UART_DEBUG_PUTC(status);
 
 		//low battery detector feature
 		#if RFM12_LOW_BATT_DETECTOR
 			if (status & (RFM12_STATUS_LBD >> 8)) {
 				//debug
-				#if RFM12_UART_DEBUG >= 2
-					uart_putc('L');
-				#endif
+                UART_DEBUG_PUTC('L');
 
 				//set status variable to low battery
 				ctrl.low_batt = RFM12_BATT_LOW;
@@ -184,9 +180,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 		#if RFM12_USE_WAKEUP_TIMER
 			if (status & (RFM12_STATUS_WKUP >> 8)) {
 				//debug
-				#if RFM12_UART_DEBUG >= 2
-					uart_putc('W');
-				#endif
+                UART_DEBUG_PUTC('W');
 
 				ctrl.wkup_flag = 1;
 				recheck_interrupt = 1;
@@ -221,10 +215,8 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 						ctrl.num_bytes = data + PACKET_OVERHEAD;
 
 						//debug
-						#if RFM12_UART_DEBUG >= 2
-							uart_putc('I');
-							uart_putc(data);
-						#endif
+                        UART_DEBUG_PUTC('I');
+                        UART_DEBUG_PUTC(data);
 
 						//see whether our buffer is free
 						//FIXME: put this into global statekeeping struct, the free state can be set by the function which pulls the packet, i guess
@@ -256,10 +248,8 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 						//check if transmission is complete
 						if (ctrl.bytecount < ctrl.num_bytes) {
 							//debug
-							#if RFM12_UART_DEBUG >= 2
-								uart_putc('R');
-								uart_putc(data);
-							#endif
+                            UART_DEBUG_PUTC('R');
+                            UART_DEBUG_PUTC(data);
 
 							//xor the remaining bytes onto the checksum
 							//note: only the header will be effectively checked
@@ -289,9 +279,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 						/* the fifo will be reset at the end of the function */
 
 						//debug
-						#if RFM12_UART_DEBUG >= 2
-							uart_putc('D');
-						#endif
+                        UART_DEBUG_PUTC('D');
 
 						//indicate that the buffer is ready to be used
 						rf_rx_buffers[ctrl.buffer_in_num].status = STATUS_COMPLETE;
@@ -313,9 +301,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 
 				case STATE_TX:
 					//debug
-					#if RFM12_UART_DEBUG >= 2
-						uart_putc('T');
-					#endif
+                    UART_DEBUG_PUTC('T');
 
 					if (ctrl.bytecount < ctrl.num_bytes) {
 						//load the next byte from our buffer struct.
@@ -367,9 +353,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 
 			//reset the receiver fifo, if receive mode is not disabled (default)
 			#if !(RFM12_TRANSMIT_ONLY)
-				#if RFM12_UART_DEBUG >= 2
-					uart_putc('F');
-				#endif
+                UART_DEBUG_PUTC('F');
 				rfm12_data( RFM12_CMD_FIFORESET | CLEAR_FIFO_INLINE);
 				rfm12_data( RFM12_CMD_FIFORESET | ACCEPT_DATA_INLINE);
 			#endif /* !(RFM12_TRANSMIT_ONLY) */
@@ -380,9 +364,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 		}
 	} while (recheck_interrupt);
 
-	#if RFM12_UART_DEBUG >= 2
-		uart_putc('E');
-	#endif
+    UART_DEBUG_PUTC('E');
 
 	//turn the int back on
 	RFM12_INT_ON();

--- a/src/rfm12.c
+++ b/src/rfm12.c
@@ -231,7 +231,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 				break;
 			case STATE_TX:
 				ctrl.rfm12_state = STATE_TX_END;
-				if (ctrl.bytecount < ctrl.num_bytes && ctrl.bytecount <RFM12_TX_BUFFER_SIZE+6) {
+				if (ctrl.bytecount < ctrl.num_bytes && ctrl.bytecount <RFM12_TX_BUFFER_SIZE+5) {
 					//Stay in TX mode if there are more bytes to TX
 					ctrl.rfm12_state = STATE_TX;
 				}
@@ -271,7 +271,7 @@ ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 				}
 				ctrl.bytecount++;
 				//Check to see if bytecount pos is at the length, if so, finished
-				if(rf_rx_buffers[ctrl.buffer_in_num].len <= ctrl.bytecount){
+				if(rf_rx_buffers[ctrl.buffer_in_num].len + RFM12_TRX_OVERHEAD <= ctrl.bytecount){
 					/* if we're here, receiving is done */
 					/* the FIFO will need to be be reset by idle state */
 					//debug

--- a/src/rfm12.c
+++ b/src/rfm12.c
@@ -138,6 +138,8 @@ void rfm12_poll(void)
 ISR(RFM12_INT_VECT, ISR_NOBLOCK)
 #endif
 {
+	uint8_t interrupt_high_inactive = nIRQ_PIN & _BV(BIT_nIRQ); // Masked input of interrupt pin for PCINT
+	if(interrupt_high_inactive)return;
 	RFM12_INT_OFF();
 	uint8_t status;
 	uint8_t recheck_interrupt  = 1;

--- a/src/rfm12.h
+++ b/src/rfm12.h
@@ -115,6 +115,11 @@ uint8_t rfm12_tx(uint8_t len, uint8_t type, uint8_t *data);
 void rfm12_poll(void);
 #endif
 
+#if RFM12_UART_DEBUG >= 2
+#define UART_DEBUG_PUTC(x) uart_putc((x))
+#else
+#define UART_DEBUG_PUTC(x) (x)
+#endif
 
 /************************
  * private control structs

--- a/src/rfm12.h
+++ b/src/rfm12.h
@@ -43,8 +43,14 @@
 #ifdef __PLATFORM_LINUX__
 #include <stdint.h>
 #endif
+#ifdef __PLATFORM_AVR__
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <avr/pgmspace.h>
+#endif
 
-//this was missing, but is very important to set the config options for structs and such
+
+//It is very important to set the config options for structs and such
 #include "include/rfm12_defaults.h"
 #include "include/rfm12_core.h"
 
@@ -118,19 +124,56 @@ void rfm12_poll(void);
 #if RFM12_UART_DEBUG >= 2
 #define UART_DEBUG_PUTC(x) uart_putc((x))
 #else
-#define UART_DEBUG_PUTC(x) (x)
+#define UART_DEBUG_PUTC(x)
 #endif
 
 /************************
  * private control structs
  */
 
+//! The communication buffer structure.
+/** \note Note that this complete buffer is transmitted sequentially,
+* beginning with the sync bytes.
+*/
+//	+-------------trx_format--------------+
+//	|             BUFFER              |sta|
+//	|len|typ |chk  |                  |   |
+//	|   |    |sum  |.... payload ...  |tus|
+//	+-------------------------------------+
+
+/** \note This type is a union of a structure
+* The structure allows access to the data
+* by member access. The array allows access to
+* the same data but with indexes.
+* The Union is then embedded in another struct
+* allowing access to the status property.
+* \see rfm12_start_tx(), rfm12_tx() and rf_tx_buffer
+* \link https://stackoverflow.com/a/26361366/3343553
+*/
+typedef struct{
+    union{
+        struct{
+            	//! Length byte - number of bytes in buffer.
+            char len;
+                	//! Type field for the simple airlab protocol.
+            char type;
+                	//! Checksum over the former two members.
+            char checksum;
+                	//! Payload of raw bytes to be transmitted.
+            char payload[RFM12_TRX_FRAME_SIZE];
+        };
+        char buffer[RFM12_TRX_FRAME_SIZE + RFM12_TRX_OVERHEAD];
+    };
+    //! Status of either STATUS_FREE or STATUS_OCCUPIED
+    buff_state status;
+} rf_trx_buffer_t;
 //! The transmission buffer structure.
 /** \note Note that this complete buffer is transmitted sequentially,
 * beginning with the sync bytes.
 *
 * \see rfm12_start_tx(), rfm12_tx() and rf_tx_buffer
 */
+
 typedef struct {
 	//! Sync bytes for receiver to start filling fifo.
 	uint8_t sync[2];
@@ -250,6 +293,7 @@ extern rf_tx_buffer_t rf_tx_buffer;
 #if !(RFM12_TRANSMIT_ONLY)
 	//buffers for storing incoming transmissions
 	extern rf_rx_buffer_t rf_rx_buffers[2];
+	extern rf_trx_buffer_t rf_rx_new_buffers[2];
 #endif /* !(RFM12_TRANSMIT_ONLY) */
 
 //the control struct

--- a/src/rfm12.h
+++ b/src/rfm12.h
@@ -59,12 +59,9 @@
 * \see rfm12_rx_status() and rfm12_control_t
 * @{
 */
-//! Indicates that the buffer is free
-#define STATUS_FREE 0
-//! Indicates that the buffer is in use by the library
-#define STATUS_OCCUPIED 1
-//! Indicates that a receive buffer holds a complete transmission
-#define STATUS_COMPLETE 2
+typedef enum{
+    STATUS_FREE, STATUS_OCCUPIED//,STATUS_COMPLETE?
+} buff_state;
 //@}
 
 
@@ -311,7 +308,7 @@ extern rfm12_control_t ctrl;
 	* \see \ref rxtx_states "rx buffer states", rfm12_rx_len(), rfm12_rx_type(), rfm12_rx_buffer(), rfm12_rx_clear() and rf_rx_buffer_t
 	*/
 	static inline uint8_t rfm12_rx_status(void) {
-		return rf_rx_buffers[ctrl.buffer_out_num].status;
+		return rf_rx_new_buffers[ctrl.buffer_out_num].status;
 	}
 
 	//! Inline function to return the rx buffer length field.
@@ -319,7 +316,7 @@ extern rfm12_control_t ctrl;
 	* \see rfm12_rx_status(), rfm12_rx_type(), rfm12_rx_buffer(), rfm12_rx_clear() and rf_rx_buffer_t
 	*/
 	static inline uint8_t rfm12_rx_len(void) {
-		return rf_rx_buffers[ctrl.buffer_out_num].len;
+		return rf_rx_new_buffers[ctrl.buffer_out_num].len;
 	}
 
 	//! Inline function to return the rx buffer type field.
@@ -327,7 +324,7 @@ extern rfm12_control_t ctrl;
 	* \see rfm12_rx_status(), rfm12_rx_len(), rfm12_rx_buffer(), rfm12_rx_clear() and rf_rx_buffer_t
 	*/
 	static inline uint8_t rfm12_rx_type(void) {
-		return rf_rx_buffers[ctrl.buffer_out_num].type;
+		return rf_rx_new_buffers[ctrl.buffer_out_num].type;
 	}
 
 	//! Inline function to retreive current rf buffer contents.
@@ -335,7 +332,7 @@ extern rfm12_control_t ctrl;
 	* \see rfm12_rx_status(), rfm12_rx_len(), rfm12_rx_type(), rfm12_rx_clear() and rf_rx_buffer_t
 	*/
 	static inline uint8_t *rfm12_rx_buffer(void) {
-		return (uint8_t*) rf_rx_buffers[ctrl.buffer_out_num].buffer;
+		return (uint8_t*) rf_rx_new_buffers[ctrl.buffer_out_num].buffer;
 	}
 #endif /* !(RFM12_TRANSMIT_ONLY) */
 

--- a/src/rfm12.h
+++ b/src/rfm12.h
@@ -65,9 +65,9 @@ typedef enum{
 //@}
 
 
-/** \name  Return values for rfm12_tx() and rfm12_start_tx()
+/** \name  Return values for rfm12_tx() and rfm12_queue_tx()
 * \anchor tx_retvals
-* \see rfm12_tx() and rfm12_start_tx()
+* \see rfm12_tx() and rfm12_queue_tx()
 * @{
 */
 //!  The packet data is longer than the internal buffer
@@ -100,14 +100,16 @@ void rfm12_set_callback ((*in_func)(uint8_t, uint8_t *));
 //FIXME: the tx function should return a status, do we need to do this also?
 // uint8_t rfm12_tx_status();
 
+void rfm12_start_tx();
+
 #if (RFM12_NORETURNS)
 //see rfm12.c for more documentation
-void rfm12_start_tx(uint8_t type, uint8_t length);
+void rfm12_queue_tx(uint8_t type, uint8_t length);
 #if !(RFM12_SMALLAPI)
 void rfm12_tx(uint8_t len, uint8_t type, uint8_t *data);
 #endif
 #else
-uint8_t rfm12_start_tx(uint8_t type, uint8_t length);
+uint8_t rfm12_queue_tx(uint8_t type, uint8_t length);
 #if !(RFM12_SMALLAPI)
 uint8_t rfm12_tx(uint8_t len, uint8_t type, uint8_t *data);
 #endif
@@ -144,7 +146,7 @@ void rfm12_poll(void);
 * the same data but with indexes.
 * The Union is then embedded in another struct
 * allowing access to the status property.
-* \see rfm12_start_tx(), rfm12_tx() and rf_tx_buffer
+* \see rfm12_queue_tx(), rfm12_tx() and rf_tx_buffer
 * \link https://stackoverflow.com/a/26361366/3343553
 */
 typedef struct{
@@ -168,7 +170,7 @@ typedef struct{
 /** \note Note that this complete buffer is transmitted sequentially,
 * beginning with the sync bytes.
 *
-* \see rfm12_start_tx(), rfm12_tx() and rf_tx_buffer
+* \see rfm12_queue_tx(), rfm12_tx() and rf_tx_buffer
 */
 
 typedef struct {
@@ -331,8 +333,15 @@ extern rfm12_control_t ctrl;
 	/** \returns A pointer to the current receive buffer contents
 	* \see rfm12_rx_status(), rfm12_rx_len(), rfm12_rx_type(), rfm12_rx_clear() and rf_rx_buffer_t
 	*/
-	static inline uint8_t *rfm12_rx_buffer(void) {
+	static inline uint8_t *rfm12_rx_entire(void) {
 		return (uint8_t*) rf_rx_new_buffers[ctrl.buffer_out_num].buffer;
+	}
+	//! Inline function to retreive current rf buffer contents.
+	/** \returns A pointer to the current receive payload contents
+	* \see rfm12_rx_status(), rfm12_rx_len(), rfm12_rx_type(), rfm12_rx_clear() and rf_rx_buffer_t
+	*/
+	static inline uint8_t *rfm12_rx_buffer(void) {
+		return (uint8_t*) rf_rx_new_buffers[ctrl.buffer_out_num].payload;
 	}
 #endif /* !(RFM12_TRANSMIT_ONLY) */
 

--- a/src/rfm12.h
+++ b/src/rfm12.h
@@ -45,6 +45,7 @@
 #endif
 
 //this was missing, but is very important to set the config options for structs and such
+#include "include/rfm12_defaults.h"
 #include "include/rfm12_core.h"
 
 /** \name States for rx and tx buffers

--- a/src/rfm12_config.h.demo
+++ b/src/rfm12_config.h.demo
@@ -119,6 +119,12 @@
 //the interrupt vector
 #define RFM12_INT_VECT (INT1_vect)
 
+//The interrupt pin and pin mask details (needed for pin change interrupt)
+// #define USE_INT_PIN_CHECK
+// #define nIRQ_PORT PORTB
+// #define nIRQ_PIN PINB
+// #define BIT_nIRQ 1
+
 //the interrupt mask register
 #define RFM12_INT_MSK GICR
 


### PR DESCRIPTION
The existing library was written using goto statements and in a way which masquerades as a State machine but it not really a state machine.

I have rewritten this interrupt as a state machine. See the diagram below:
![New_ISR_model](https://user-images.githubusercontent.com/693456/68131306-bbff2480-ff14-11e9-9202-63789da56953.PNG)
No gotos now and it behaves much more like a state machine.

Also the UART debug statements have been compressed into a macro.

The structure that stores the bytes for received bytes has been made into a union so just the buffer can be written to as raw and the properties can be accessed separately.
```
//	+-------------trx_format--------------+
//	|             BUFFER              |sta|
//	|len|typ |chk  |                  |   |
//	|   |    |sum  |.... payload ...  |tus|
//	+-------------------------------------+
```
The Tx buffer struct could be constructed as struct of the rf_trx_buffer_t and the sync bytes. This would allow the txbuff state to be stored with the txbuffer